### PR TITLE
dependabotにassigneesを設定

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,13 @@ updates:
     schedule:
       interval: "weekly"
       timezone: "Asia/Tokyo"
+    assignees:
+      - "yosuke-homma"
 
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
       interval: "weekly"
       timezone: "Asia/Tokyo"
+    assignees:
+      - "yosuke-homma"


### PR DESCRIPTION
## やったこと
dependabotにassigneesを設定
参考記事：https://docs.github.com/ja/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#assignees