### PR TITLE
ExamsControllerのcreateアクションとdestroyアクションのテストを追加 / Add tests for create and destroy action on ExamsController

### DIFF
--- a/app/controllers/exams_controller.rb
+++ b/app/controllers/exams_controller.rb
@@ -16,6 +16,7 @@ class ExamsController < ApplicationController
   end
 
   def create
+    # debugger
     @exam = current_user.exams.build(exam_params)
     @exam.review = Openai.new.review(exam_params['question'], exam_params['answer'])
     if @exam.save

--- a/app/controllers/exams_controller.rb
+++ b/app/controllers/exams_controller.rb
@@ -16,7 +16,6 @@ class ExamsController < ApplicationController
   end
 
   def create
-    # debugger
     @exam = current_user.exams.build(exam_params)
     @exam.review = Openai.new.review(exam_params['question'], exam_params['answer'])
     if @exam.save

--- a/spec/request/exam_spec.rb
+++ b/spec/request/exam_spec.rb
@@ -71,14 +71,16 @@ RSpec.describe 'ExamsController', type: :request do
     let(:exam) { FactoryBot.create(:exam) }
 
     context '正常系' do
-      it '受験履歴の削除に成功し、rootにリダイレクトすること' do
+      before do
         sign_in exam.user
+      end
+
+      it '受験履歴の削除に成功し、rootにリダイレクトすること' do
         delete exam_path exam
         expect(response).to redirect_to root_url
       end
 
       it '受験履歴の削除に成功し、受験履歴の数が1つ減ること' do
-        sign_in exam.user
         expect do
           delete exam_path exam
         end.to change(Exam, :count).by(-1)

--- a/spec/request/exam_spec.rb
+++ b/spec/request/exam_spec.rb
@@ -38,4 +38,42 @@ RSpec.describe 'ExamsController', type: :request do
       expect(response.body).to include exam.review
     end
   end
+
+  describe '#destroy' do
+    let(:exam) { FactoryBot.create(:exam) }
+
+    context '正常系' do
+      it '受験履歴の削除に成功し、rootにリダイレクトすること' do
+        sign_in exam.user
+        delete exam_path exam
+        expect(response).to redirect_to root_url
+      end
+
+      it '受験履歴の削除に成功し、受験履歴の数が1つ減ること' do
+        sign_in exam.user
+        expect do
+          delete exam_path exam
+        end.to change(Exam, :count).by(-1)
+      end
+    end
+
+    context '異常系' do
+      context 'ログインしていない場合' do
+        it 'ログインページにリダイレクトすること' do
+          delete exam_path exam
+          expect(response).to redirect_to new_user_session_path
+        end
+      end
+
+      context '他のユーザーの受験履歴を削除しようとした場合' do
+        let(:other_user) { FactoryBot.create(:user, email: 'otheruser@email.com') }
+
+        it 'rootにリダイレクトすること' do
+          sign_in other_user
+          delete exam_path exam
+          expect(response).to redirect_to root_url
+        end
+      end
+    end
+  end
 end

--- a/spec/request/exam_spec.rb
+++ b/spec/request/exam_spec.rb
@@ -11,10 +11,12 @@ RSpec.describe 'ExamsController', type: :request do
   describe '#new' do
     let(:user) { FactoryBot.create(:user) }
 
-    it '画面の表示に成功すること', openai: true do
-      sign_in user
-      get new_exam_path
-      expect(response).to have_http_status(:ok)
+    context '正常系', openai: true do
+      it '画面の表示に成功すること' do
+        sign_in user
+        get new_exam_path
+        expect(response).to have_http_status(:ok)
+      end
     end
 
     context '異常系' do

--- a/spec/request/exam_spec.rb
+++ b/spec/request/exam_spec.rb
@@ -49,6 +49,15 @@ RSpec.describe 'ExamsController', type: :request do
         end.to change(Exam, :count).by(1)
       end
     end
+
+    context '異常系' do
+      context 'ログインしていない場合' do
+        it 'ログインページにリダイレクトすること' do
+          post exams_path, params: { exam: exam_params }
+          expect(response).to redirect_to new_user_session_path
+        end
+      end
+    end
   end
 
   describe '#show' do

--- a/spec/request/exam_spec.rb
+++ b/spec/request/exam_spec.rb
@@ -24,14 +24,14 @@ RSpec.describe 'ExamsController', type: :request do
   end
 
   describe '#show' do
-    it '画面の表示に成功すること', openai: true do
-      exam = FactoryBot.create(:exam)
+    let(:exam) { FactoryBot.create(:exam) }
+
+    it '画面の表示に成功すること' do
       get exam_path exam
       expect(response).to have_http_status(:ok)
     end
 
-    it 'テストの内容と一致すること', openai: true do
-      exam = FactoryBot.create(:exam)
+    it 'テストの内容と一致すること' do
       get exam_path exam
       expect(response.body).to include exam.question
       expect(response.body).to include exam.answer

--- a/spec/request/exam_spec.rb
+++ b/spec/request/exam_spec.rb
@@ -29,6 +29,28 @@ RSpec.describe 'ExamsController', type: :request do
     end
   end
 
+  describe '#create' do
+    let(:user) { FactoryBot.create(:user) }
+    let(:exam_params) { FactoryBot.attributes_for(:exam).except(:review) }
+
+    context '正常系', openai: true do
+      before do
+        sign_in user
+      end
+
+      it '受験結果の保存に成功し、受験結果のページにリダイレクトすること' do
+        post exams_path, params: { exam: exam_params }
+        expect(response).to redirect_to exam_path(user.exams.last)
+      end
+
+      it '受験結果の保存に成功し、受験履歴が1つ増えること' do
+        expect do
+          post exams_path, params: { exam: exam_params }
+        end.to change(Exam, :count).by(1)
+      end
+    end
+  end
+
   describe '#show' do
     let(:exam) { FactoryBot.create(:exam) }
 

--- a/spec/request/exam_spec.rb
+++ b/spec/request/exam_spec.rb
@@ -17,9 +17,13 @@ RSpec.describe 'ExamsController', type: :request do
       expect(response).to have_http_status(:ok)
     end
 
-    it 'ログインしていない場合、ログインページにリダイレクトされること' do
-      get new_exam_path
-      expect(response).to redirect_to new_user_session_path
+    context '異常系' do
+      context 'ログインしていない場合' do
+        it 'ログインしていない場合、ログインページにリダイレクトされること' do
+          get new_exam_path
+          expect(response).to redirect_to new_user_session_path
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## やったこと
- ExamsControllerのcreateアクションとdestroyアクションのテストを追加 / Add tests for create and destroy action on ExamsController
- DRYにするなど、細かいリファクタリング

closes #42 