### PR TITLE
カウントダウンタイマー開始時にフォームが提出されてしまうバグを修正 / Fix the bug where the form is submitted when the countdown timer starts

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,6 +1,5 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
-import { Turbo } from "@hotwired/turbo-rails"
-Turbo.session.drive = false
+import "@hotwired/turbo-rails"
 import "controllers"
 import "./custom/count"
 import "./custom/countdown"

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,5 +1,6 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
-import "@hotwired/turbo-rails"
+import { Turbo } from "@hotwired/turbo-rails"
+Turbo.session.drive = false
 import "controllers"
 import "./custom/count"
 import "./custom/countdown"

--- a/app/views/exams/new.html.erb
+++ b/app/views/exams/new.html.erb
@@ -1,4 +1,4 @@
-<h1>IELTS Writing Task2<h1>
+<h1>IELTS Writing Task2</h1>
 <div>
   <%= form_with model: @exam do |form| %>
     <%= render 'shared/error_messages' %>
@@ -9,8 +9,8 @@
       <p id="word_count">0</p>
       <div>
         <p id="timer">40:00</p>
-        <button id="startBtn">Start</button>
-        <button id="stopBtn">Stop</button>
+        <input id="startBtn" type="button" value="Start">
+        <input id="stopBtn" type="button" value="Stop">
       </div>
     </div>
     <%= form.submit "Submit" %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,7 +3,7 @@
   <nav>
     <li><%= link_to 'History', exams_path %></li>
     <% if user_signed_in? %>
-      <li><%= link_to 'New exam', new_exam_path %></li>
+      <li><%= link_to 'New exam', new_exam_path, data: { turbo: false } %></li>
       <li><%= link_to 'Users', users_path %></li>
       <li><%= link_to 'Edit user', edit_user_registration_path %></li>
       <li><%= button_to 'Log out', destroy_user_session_path, method: :delete, class: 'logout-btn' %></li>

--- a/app/views/statics/index.html.erb
+++ b/app/views/statics/index.html.erb
@@ -1,7 +1,7 @@
 <h1>Boost your writing skills and achieve your IELTS goals with ChatGPT!</h1>
 <% if user_signed_in? %>
   <button>
-    <%= link_to 'Start new exam', new_exam_path %>
+    <%= link_to 'Start new exam', new_exam_path, data: { turbo: false } %>
   </button>
 <% else %>
   <button><%= link_to 'Sign up', new_user_registration_path %></button>


### PR DESCRIPTION
## やったこと
1. カウントダウンタイマー開始時にフォームが提出されてしまうバグを修正 / Fix the bug where the form is submitted when the countdown timer starts
button要素からinput要素に置き換えることで、確実にformが提出されないように修正

2. リロードなしでJavascriptが動かない事象を修正 / Fix the bug where JavaScript doesn't work without refreshing the page
参考記事：https://stackoverflow.com/questions/71110271/events-not-loading-on-first-page-load-but-works-after-refresh
参考ドキュメント：https://github.com/hotwired/turbo-rails#navigate-with-turbo-drive

closes #70 