### PR TITLE
パフォーマンス調査用にrack-mini-profilerを追加 / Add rack-mini-profiler gem for performance assessment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,7 @@ group :development do
   gem 'rubocop-performance', require: false
 
   # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
-  # gem "rack-mini-profiler"
+  gem "rack-mini-profiler"
 
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,6 +169,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.6.2)
     rack (2.2.7)
+    rack-mini-profiler (3.1.0)
+      rack (>= 1.2.0)
     rack-test (2.1.0)
       rack (>= 1.3)
     rails (7.0.5)
@@ -320,6 +322,7 @@ DEPENDENCIES
   jbuilder
   pg (~> 1.5)
   puma (~> 6.2)
+  rack-mini-profiler
   rails (~> 7.0.5)
   rspec-rails (~> 6.0.2)
   rubocop


### PR DESCRIPTION
## やったこと
パフォーマンス調査用にrack-mini-profiler gemを追加
参考記事：https://techblog.gmo-ap.jp/2020/06/08/rack-mini-profiler/

closes #72 