### PR TITLE
github actionsの実行タイミングを修正 / Modify the execution timing of GitHub Actions

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,5 +1,9 @@
 name: Test
-on: [push, pull_request]
+on: 
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    type: [ opened, reopened ]
 
 jobs:
   rspec:

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,6 +1,10 @@
 # ref https://github.com/everyleaf/el-training/blob/master/github_actions/.github/workflows/lint.yml
 name: Lint
-on: [push, pull_request]
+on: 
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    type: [ opened, reopened ]
 
 jobs:
   lint:


### PR DESCRIPTION
## チケットへのリンク
closes #83 

## やったこと
github actionsの実行タイミングを修正
修正前はpull request作成時に各チェックが2つずつ実行されていたため。
push時の実行について、ブランチを指定していなかったことが原因。

## やらないこと

## 動作確認

## その他
