### PR TITLE
bullet gemをアップデート

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
     addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
-    base64 (0.1.1)
+    base64 (0.2.0)
     bcrypt (3.1.18)
     bigdecimal (3.1.4)
     bindex (0.8.1)
@@ -85,7 +85,7 @@ GEM
       msgpack (~> 1.2)
     brakeman (6.0.0)
     builder (3.2.4)
-    bullet (7.0.7)
+    bullet (7.1.3)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     capybara (3.39.2)
@@ -116,7 +116,7 @@ GEM
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
       railties (>= 3.2)
-    drb (2.1.1)
+    drb (2.2.0)
       ruby2_keywords
     erubi (1.12.0)
     erubis (2.7.0)
@@ -176,7 +176,7 @@ GEM
     minitest (5.20.0)
     msgpack (1.7.0)
     multipart-post (2.3.0)
-    mutex_m (0.1.2)
+    mutex_m (0.2.0)
     net-imap (0.4.1)
       date
       net-protocol
@@ -392,4 +392,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.4.13
+   2.4.22


### PR DESCRIPTION
## 背景

bullet gemのバージョンがActiveRecordのバージョン（7.1.1）に対応していなかったため、bulletのバージョンを上げる

## やったこと

bulletのバージョンアップ

## やらないこと

## 動作確認

## その他
